### PR TITLE
feat(ui): API playground + health, voice embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,19 @@ See `.env.example` for placeholders (`NEXT_PUBLIC_SITE_URL`, future keys). None 
 - Add future email / analytics keys in `.env` when extending.
 
 Generated on 2025-10-03.
+
+## UI Overview
+
+Home (/) provides:
+
+- API Playground to POST /api/run with fields: name, phone, reason, action, lang
+- Health panel that fetches /api/healthz with a Refresh button
+- Collapsible boxes to inspect request/response JSON and health payloads
+
+Voice (/voice):
+
+- Embeds `public/voice-demo/setup.html` in an iframe; includes a fallback link and a back-to-home link
+
+Accessibility/UX:
+
+- Labels on inputs, visible focus states, basic error summary with aria-live on results

--- a/app/components/Collapsible.tsx
+++ b/app/components/Collapsible.tsx
@@ -1,0 +1,14 @@
+"use client"
+import { useState, PropsWithChildren } from 'react'
+
+export default function Collapsible({ title, children }: PropsWithChildren<{ title: string }>) {
+  const [open, setOpen] = useState(true)
+  return (
+    <div className="collapsible">
+      <button className="collapsible__toggle" aria-expanded={open} onClick={() => setOpen(v => !v)}>
+        {open ? '▾' : '▸'} {title}
+      </button>
+      {open && <div className="collapsible__content" aria-live="polite">{children}</div>}
+    </div>
+  )
+}

--- a/app/components/HealthPanel.tsx
+++ b/app/components/HealthPanel.tsx
@@ -1,0 +1,42 @@
+"use client"
+import { useEffect, useState } from 'react'
+import Collapsible from './Collapsible'
+
+export default function HealthPanel() {
+  const [data, setData] = useState<any>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function load() {
+    setLoading(true); setError(null)
+    try {
+      const res = await fetch('/api/healthz', { cache: 'no-store' })
+      const json = await res.json()
+      setData(json)
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to fetch')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { load() }, [])
+
+  return (
+    <div>
+      <h2>Health</h2>
+      <div className="card">
+        <div className="actions">
+          <a href="/api/healthz" target="_blank" rel="noreferrer">Open raw</a>
+          <button onClick={load} disabled={loading}>{loading ? 'Refreshing…' : 'Refresh'}</button>
+        </div>
+        {error && <div className="error" role="alert">{error}</div>}
+        <div aria-live="polite">
+          <Collapsible title="/api/healthz JSON">
+            <pre>{data ? JSON.stringify(data, null, 2) : '—'}</pre>
+          </Collapsible>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/RunForm.tsx
+++ b/app/components/RunForm.tsx
@@ -1,0 +1,102 @@
+"use client"
+import { useState } from 'react'
+import Collapsible from './Collapsible'
+
+type RunBody = {
+  name?: string
+  phone?: string
+  reason?: string
+  action?: string
+  lang?: 'en' | 'lt'
+}
+
+type ErrorIssue = { path?: string; message: string }
+
+export default function RunForm() {
+  const [body, setBody] = useState<RunBody>({ lang: 'en' })
+  const [status, setStatus] = useState<number | null>(null)
+  const [errors, setErrors] = useState<ErrorIssue[] | null>(null)
+  const [response, setResponse] = useState<any>(null)
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setStatus(null); setErrors(null); setResponse(null)
+    try {
+      const res = await fetch('/api/run', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      })
+      setStatus(res.status)
+      const json = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setErrors(json?.errors ?? [{ message: 'Unknown error' }])
+      }
+      setResponse(json)
+    } catch (err: any) {
+      setStatus(0)
+      setErrors([{ message: err?.message ?? 'Network error' }])
+    }
+  }
+
+  function set<K extends keyof RunBody>(key: K) {
+    return (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+      setBody({ ...body, [key]: e.target.value })
+  }
+
+  return (
+    <div>
+      <h2>API Playground</h2>
+      <form onSubmit={onSubmit} className="card" aria-describedby="error-summary">
+        <div className="grid-2">
+          <div>
+            <label htmlFor="name">Name</label>
+            <input id="name" type="text" onChange={set('name')} value={body.name ?? ''} />
+          </div>
+          <div>
+            <label htmlFor="phone">Phone</label>
+            <input id="phone" type="tel" onChange={set('phone')} value={body.phone ?? ''} />
+          </div>
+          <div className="col-span-2">
+            <label htmlFor="reason">Reason</label>
+            <textarea id="reason" rows={3} onChange={set('reason')} value={body.reason ?? ''} />
+          </div>
+          <div>
+            <label htmlFor="action">Action</label>
+            <input id="action" type="text" onChange={set('action')} value={body.action ?? ''} />
+          </div>
+          <div>
+            <label htmlFor="lang">Language</label>
+            <select id="lang" onChange={set('lang')} value={body.lang ?? 'en'}>
+              <option value="en">English</option>
+              <option value="lt">Lietuvių</option>
+            </select>
+          </div>
+        </div>
+        <div className="actions">
+          <button type="submit">Send</button>
+          {status !== null && <span className="status">HTTP {status}</span>}
+        </div>
+      </form>
+
+      {errors && errors.length > 0 && (
+        <div id="error-summary" className="error" role="alert" aria-live="polite">
+          <strong>Errors:</strong>
+          <ul>
+            {errors.map((e, i) => (
+              <li key={i}>{e.path ? `${e.path}: ` : ''}{e.message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="stack">
+        <Collapsible title="Request JSON">
+          <pre>{JSON.stringify(body, null, 2)}</pre>
+        </Collapsible>
+        <Collapsible title="Response JSON">
+          <pre>{response ? JSON.stringify(response, null, 2) : '—'}</pre>
+        </Collapsible>
+      </div>
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,25 @@
+:root { --bg:#0b0c10; --panel:#111319; --muted:#a0a3ad; --text:#e9eaf0; --primary:#4da3ff; --error:#ff6b6b; }
+html,body{ height:100%; }
+body{ margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; background:var(--bg); color:var(--text); }
+a{ color:var(--primary); }
+header{ border-bottom:1px solid #1a1d25; background:#0d0f15; }
+nav{ max-width:1100px; margin:0 auto; padding:0.75rem 1rem; display:flex; gap:1rem; align-items:center; }
+nav a{ text-decoration:none; }
+.container{ max-width:1100px; margin:2rem auto; padding:0 1rem; }
+.grid{ display:grid; grid-template-columns: 1fr 1fr; gap:1rem; }
+@media (max-width: 800px){ .grid{ grid-template-columns: 1fr; } }
+.card{ background:var(--panel); border:1px solid #1a1d25; border-radius:8px; padding:1rem; }
+.grid-2{ display:grid; grid-template-columns: 1fr 1fr; gap:0.75rem; }
+.col-span-2{ grid-column: span 2; }
+label{ display:block; font-size:0.85rem; color:var(--muted); margin-bottom:0.25rem; }
+input, select, textarea{ width:100%; background:#0b0c12; border:1px solid #222736; color:var(--text); border-radius:6px; padding:0.6rem 0.7rem; }
+input:focus, select:focus, textarea:focus, button:focus{ outline:2px solid var(--primary); outline-offset:2px; }
+button{ appearance:none; background:var(--primary); color:#041423; border:none; border-radius:6px; padding:0.6rem 0.9rem; cursor:pointer; }
+button[disabled]{ opacity:0.6; cursor:not-allowed; }
+.actions{ display:flex; gap:0.75rem; align-items:center; justify-content:flex-end; }
+.status{ color:var(--muted); font-size:0.9rem; }
+.stack{ display:grid; gap:0.75rem; margin-top:0.75rem; }
+.collapsible__toggle{ width:100%; text-align:left; background:#131725; color:var(--text); border:1px solid #1f2435; padding:0.5rem 0.7rem; border-radius:6px; }
+.collapsible__content{ margin-top:0.5rem; }
+.error{ background:#2b0f13; border:1px solid #5b1d24; color:#ffb3b3; padding:0.75rem; border-radius:6px; margin-top:0.75rem; }
+h1{ margin-top:0; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import './globals.css'
 export default function RootLayout({
   children,
 }: {
@@ -5,7 +6,16 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <header>
+          <nav>
+            <a href="/">Home</a>
+            <a href="/voice">Voice</a>
+            <a href="/api/healthz" target="_blank" rel="noreferrer">/api/healthz</a>
+          </nav>
+        </header>
+        <main className="container">{children}</main>
+      </body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,15 @@
+import RunForm from './components/RunForm'
+import HealthPanel from './components/HealthPanel'
+
 export default function Home() {
   return (
     <div>
-      <h1>Automation Engine Demo</h1>
-      <p>Welcome to the automation engine demo!</p>
-      <ul>
-        <li><a href="/api/healthz">Health Check</a></li>
-        <li><a href="/voice-demo/setup.html">Voice Demo</a></li>
-        <li><a href="/voice">Voice Page</a></li>
-      </ul>
+      <h1>Automation Engine</h1>
+      <p style={{ color: '#a0a3ad' }}>Play with the API and watch health in real time.</p>
+      <div className="grid">
+        <div className="card"><RunForm /></div>
+        <div className="card"><HealthPanel /></div>
+      </div>
     </div>
   )
 }

--- a/app/voice/page.tsx
+++ b/app/voice/page.tsx
@@ -1,36 +1,17 @@
 export default function VoicePage() {
+  const demoPath = '/voice-demo/setup.html'
+  // No runtime FS check on server; we just link/iframe and let the browser handle 404 if missing
   return (
-    <div style={{ maxWidth: '600px', margin: '2rem auto', padding: '0 1rem' }}>
-      <h1>Voice Demo</h1>
-      <p>Welcome to the voice automation demo!</p>
-      
-      <div style={{ marginBottom: '2rem' }}>
-        <h2>Available Demos:</h2>
-        <ul>
-          <li>
-            <a href="/voice-demo/setup.html" style={{ color: '#007bff', textDecoration: 'none' }}>
-              Interactive Form Demo
-            </a>
-            <p style={{ color: '#666', fontSize: '0.9rem' }}>
-              Fill out a form and see how the automation engine processes your request
-            </p>
-          </li>
-        </ul>
+    <div className="container">
+      <h1>Voice</h1>
+      <p style={{ color: '#a0a3ad' }}>Embedded static demo from <code>public/voice-demo</code>.</p>
+      <div className="card" style={{ padding: 0 }}>
+        <iframe src={demoPath} title="Voice Demo" style={{ width: '100%', height: '70vh', border: 'none' }} />
       </div>
-      
-      <div style={{ backgroundColor: '#f8f9fa', padding: '1rem', borderRadius: '4px' }}>
-        <h3>API Endpoints:</h3>
-        <ul>
-          <li><code>/api/healthz</code> - Health check and statistics</li>
-          <li><code>/api/run</code> - Submit automation requests</li>
-        </ul>
-      </div>
-      
-      <div style={{ marginTop: '2rem' }}>
-        <a href="/" style={{ color: '#007bff', textDecoration: 'none' }}>
-          ← Back to Home
-        </a>
-      </div>
+      <p style={{ marginTop: '1rem' }}>
+        If the demo doesn’t load, open <a href={demoPath} target="_blank" rel="noreferrer">{demoPath}</a> in a new tab.
+      </p>
+      <p><a href="/">← Back to Home</a></p>
     </div>
   )
 }


### PR DESCRIPTION
Implements a minimal, production-safe UI with a form to call /api/run, a live /api/healthz panel, and an embedded Voice demo.\n\n- Home (/) two-column layout: RunForm (POST /api/run) and HealthPanel (GET /api/healthz)\n- Error handling and status display; collapsible JSON request/response\n- Responsive CSS (no new libs), accessible labels and focus states\n- /voice page embeds public/voice-demo/setup.html with fallback link\n- README updated with UI overview section\n\nQuality gates:\n- npm test: PASS\n- next build: PASS\n\nNon-goals kept: no Tailwind/shadcn, no secrets, binds to .\n